### PR TITLE
Add Ascend Quant Config

### DIFF
--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -36,6 +36,10 @@ class NPUPlatform(Platform):
     ray_device_key: str = "NPU"
     device_control_env_var: str = "ASCEND_RT_VISIBLE_DEVICES"
 
+    supported_quantization: list[str] = [
+        "ascend"
+    ]
+
     @classmethod
     def get_device_capability(cls, device_id: int = 0):
         return None

--- a/vllm_ascend/quant_config.py
+++ b/vllm_ascend/quant_config.py
@@ -27,7 +27,7 @@ from vllm.model_executor.layers.linear import (LinearBase, LinearMethodBase,
 from vllm.model_executor.layers.quantization import (register_quantization_config)
 from vllm.model_executor.layers.quantization.base_config import (QuantizationConfig)
 from vllm.model_executor.parameter import (BasevLLMParameter,
-                                           GroupQuantScaleParameter,
+                                           ChannelQuantScaleParameter,
                                            PackedvLLMParameter,
                                            ModelWeightParameter)
 try:
@@ -150,9 +150,8 @@ class AscendLinearMethod(LinearMethodBase):
             if perchannel_name in weights.keys():
                 layer.register_parameter(
                     perchannel_name,
-                    GroupQuantScaleParameter(
+                    ChannelQuantScaleParameter(
                         data=weights[perchannel_name],
-                        input_dim=0,
                         output_dim=0,
                         weight_loader=weight_loader
                     )

--- a/vllm_ascend/quant_config.py
+++ b/vllm_ascend/quant_config.py
@@ -1,0 +1,179 @@
+"""
+Copyright (c) Huawei Technologies Co., Ltd. 2024-2025. All rights reserved.
+MindIE is licensed under Mulan PSL v2.
+You can use this software according to the terms and conditions of the Mulan PSL v2.
+You may obtain a copy of Mulan PSL v2 at:
+         http://license.coscl.org.cn/MulanPSL2
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+See the Mulan PSL v2 for more details.
+"""
+
+from typing import Any, Dict, List, Optional
+
+import torch
+import torch_npu
+
+from vllm import _custom_ops as ops
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import (LinearBase, LinearMethodBase,
+                                               UnquantizedLinearMethod, RowParallelLinear)
+from vllm.model_executor.layers.quantization import (register_quantization_config)
+from vllm.model_executor.layers.quantization.base_config import (QuantizationConfig)
+from vllm.model_executor.parameter import (BasevLLMParameter,
+                                           GroupQuantScaleParameter,
+                                           PackedvLLMParameter,
+                                           ModelWeightParameter)
+try:
+    from mindie_turbo import get_quantizer, BaseQuantizer
+except:
+    pass
+
+logger = init_logger(__name__)
+
+@register_quantization_config("ascend")
+class AscendConfig(QuantizationConfig):
+    """Config class for Ascend"""
+
+    def __init__(self, quantizer: BaseQuantizer):
+        self.quantizer = quantizer
+
+    def __repr__(self) -> str:
+        return "AscendConfig:\n" + super().__repr__()
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "ascend"
+
+    @classmethod
+    def get_supported_act_dtypes(cls) -> List[torch.dtype]:
+        return [torch.half, torch.bfloat16]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 80
+
+    @classmethod
+    def get_config_filenames(cls) -> List[str]:
+        return ["quantize_config.json"]
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "AscendConfig":
+        return cls(get_quantizer(config))
+
+    @classmethod
+    def override_quantization_method(cls, hf_quant_cfg,
+                                     user_quant) -> Optional[str]:
+        dev_type = hf_quant_cfg.get("dev_type", None)
+        if dev_type == "npu":
+            return "ascend"
+        return None
+
+    def get_quant_method(self, layer: torch.nn.Module,
+                         prefix: str) -> Optional["QuantizeMethodBase"]:
+        if isinstance(layer, LinearBase):
+            return AscendLinearMethod(self.quantizer)
+        return None
+
+    def get_scaled_act_names(self) -> List[str]:
+        return []
+
+
+class AscendLinearMethod(LinearMethodBase):
+    """Linear method for Ascend quantization.
+
+    Args:
+        quantizer: The Ascend quantization interface.
+    """
+
+    def __init__(self, quantizer: BaseQuantizer) -> None:
+        self.quantizer = quantizer
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: List[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        del output_size
+        output_size_per_partition = sum(output_partition_sizes)
+        weight_loader = extra_weight_attrs.get("weight_loader")
+
+        # Normalize group_size
+        # if self.quantizer.group_size <= 0:
+        #     group_size = self.quant_config.group_size
+        # else:
+        #     group_size = input_size
+
+        layer.input_size = input_size_per_partition
+        layer.output_size = output_size_per_partition
+        
+        self.quantizer.register_linear_parameter(
+            layer,
+            layer.input_size,
+            layer.output_size,
+            params_dtype
+        )
+    
+        weight = self.quantizer.get_weight(layer)
+        if isinstance(layer, RowParallelLinear):
+            layer.register_parameter(
+                "weight",
+                ModelWeightParameter(
+                    data=self.quantizer.get_weight(layer).data.transpose(0, 1),
+                    input_dim=1,
+                    output_dim=0,
+                    weight_loader=weight_loader
+                )
+            )
+        else:
+            layer.register_parameter(
+                "weight",
+                ModelWeightParameter(
+                    data=self.quantizer.get_weight(layer).data,
+                    input_dim=0,
+                    output_dim=1,
+                    weight_loader=weight_loader
+                )
+            )
+        
+        pertensor_params = self.quantizer.get_pertensor_param(layer)
+        for name, param in pertensor_params.items():
+            layer.register_parameter(
+                name,
+                BasevLLMParameter(
+                    data=param.data,
+                    weight_loader=weight_loader
+                )
+            )
+        
+        perchannel_params = self.quantizer.get_perchannel_param(layer)
+        for name, param in perchannel_params.items():
+            layer.register_parameter(
+                name,
+                GroupQuantScaleParameter(
+                    data=param.data,
+                    input_dim=0,
+                    output_dim=0,
+                    weight_loader=weight_loader
+                )
+            )
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if isinstance(layer, RowParallelLinear):
+            layer.weight.data = layer.weight.data.transpose(1, 0)
+        layer.input_scale = torch.nn.Parameter(torch.broadcast_to(layer.input_scale, (layer.input_size, )), requires_grad=False)
+        layer.input_offset = torch.nn.Parameter(torch.broadcast_to(layer.input_offset, (layer.input_size, )), requires_grad=False)
+        
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        return self.quantizer.linear_quant_method.apply(layer, x, bias)

--- a/vllm_ascend/quantize/quant_config.py
+++ b/vllm_ascend/quantize/quant_config.py
@@ -20,20 +20,15 @@ from typing import Any, Dict, List, Optional
 import torch
 import torch_npu
 
-from vllm import _custom_ops as ops
 from vllm.logger import init_logger
-from vllm.model_executor.layers.linear import (LinearBase, LinearMethodBase,
-                                               UnquantizedLinearMethod, RowParallelLinear)
+from vllm.model_executor.layers.linear import (LinearBase, LinearMethodBase)
 from vllm.model_executor.layers.quantization import (register_quantization_config)
 from vllm.model_executor.layers.quantization.base_config import (QuantizationConfig)
 from vllm.model_executor.parameter import (BasevLLMParameter,
                                            ChannelQuantScaleParameter,
                                            PackedvLLMParameter,
                                            ModelWeightParameter)
-try:
-    from mindie_turbo import MindIETurboQuantizer
-except:
-    NotImplementedError("Currently Ascend quantization only supports implementations from MindIETurbo plugins.")
+from .quantizer import AscendQuantizer
 
 logger = init_logger(__name__)
 
@@ -43,7 +38,7 @@ class AscendQuantConfig(QuantizationConfig):
 
     def __init__(self, quant_config: Dict[str, Any]):
         self.quant_config = quant_config
-        self.quantizer = MindIETurboQuantizer.get_quantizer(quant_config)
+        self.quantizer = AscendQuantizer.get_quantizer(quant_config)
 
     def __repr__(self) -> str:
         return "AscendQuantConfig:\n" + super().__repr__()

--- a/vllm_ascend/quantize/quantizer.py
+++ b/vllm_ascend/quantize/quantizer.py
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from typing import Any, Dict
+
+CUSTOMIZED_QUANTIZER_TYPE = []
+
+class AscendQuantizer:
+    """An iterface to different quantization implementations for ascend hardwares."""
+
+    @classmethod
+    def get_quantizer(cls, quant_config: Dict[str, Any]):
+        # TODO: Need a param to choose quantization algorithms.
+        quantization_algorithm = ''
+
+        if quantization_algorithm in CUSTOMIZED_QUANTIZER_TYPE:
+            return
+
+        try:
+            from mindie_turbo import MindIETurboQuantizer
+            return MindIETurboQuantizer.get_quantizer(quant_config)
+        except:
+            raise NotImplementedError("There is no available ascend quantizer.")
+
+    def build_linear_method(self):
+        raise NotImplementedError
+
+    def build_moe_method(self):
+        raise NotImplementedError
+
+    def build_attention_method(self):
+        raise NotImplementedError


### PR DESCRIPTION
This pr adds an AscendConfig class for ascend quantization so that vllm can  recognize and parse the configuration of ascend quantized models. Besides, it adds a AscendLinearMethod class which enables vllm to use specific quantized linear implementations(e.g. from MindIE Turbo).