### PR TITLE
[WORKER] Enable npu profiling

### DIFF
--- a/vllm_ascend/worker.py
+++ b/vllm_ascend/worker.py
@@ -3,10 +3,12 @@ from typing import Dict, List, Optional, Tuple, Type
 
 import torch
 import torch.distributed
+from vllm import envs
 from vllm.config import ParallelConfig, VllmConfig
 from vllm.distributed import (ensure_model_parallel_initialized,
                               init_distributed_environment,
                               set_custom_all_reduce)
+from vllm.logger import init_logger
 from vllm.model_executor import set_random_seed
 from vllm.platforms import current_platform
 from vllm.sequence import SequenceGroupMetadata
@@ -18,6 +20,8 @@ from vllm.worker.worker import Worker
 from vllm.worker.worker_base import WorkerBase
 
 from vllm_ascend.model_runner import NPUModelRunner
+
+logger = init_logger(__name__)
 
 
 class NPUWorker(Worker):
@@ -92,6 +96,41 @@ class NPUWorker(Worker):
         # Initialize gpu_cache as embedding models don't initialize kv_caches
         self.gpu_cache: Optional[List[List[torch.Tensor]]] = None
         self._seq_group_metadata_cache: Dict[str, SequenceGroupMetadata] = {}
+
+        # Torch profiler. Enabled and configured through env vars:
+        # VLLM_TORCH_PROFILER_DIR=/path/to/save/trace
+        if envs.VLLM_TORCH_PROFILER_DIR:
+            print(envs.VLLM_TORCH_PROFILER_DIR)
+            torch_profiler_trace_dir = envs.VLLM_TORCH_PROFILER_DIR
+            logger.info("Profiling enabled. Traces will be saved to: %s",
+                        torch_profiler_trace_dir)
+            import torch_npu
+
+            experimental_config = torch_npu.profiler._ExperimentalConfig(
+                export_type=torch_npu.profiler.ExportType.Text,
+                profiler_level=torch_npu.profiler.ProfilerLevel.Level0,
+                msprof_tx=False,
+                aic_metrics=torch_npu.profiler.AiCMetrics.AiCoreNone,
+                l2_cache=False,
+                op_attr=False,
+                data_simplification=False,
+                record_op_args=False,
+                gc_detect_threshold=None,
+            )
+
+            self.profiler = torch_npu.profiler.profile(
+                activities=[
+                    torch_npu.profiler.ProfilerActivity.CPU,
+                    torch_npu.profiler.ProfilerActivity.NPU,
+                ],
+                with_stack=True,
+                profile_memory=True,
+                with_modules=True,
+                experimental_config=experimental_config,
+                on_trace_ready=torch_npu.profiler.tensorboard_trace_handler(
+                    torch_profiler_trace_dir))
+        else:
+            self.profiler = None
 
     def init_device(self) -> None:
         if self.device_config.device.type == "npu":

--- a/vllm_ascend/worker.py
+++ b/vllm_ascend/worker.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Optional, Tuple, Type
 
 import torch
 import torch.distributed
+import torch_npu
 from vllm import envs
 from vllm.config import ParallelConfig, VllmConfig
 from vllm.distributed import (ensure_model_parallel_initialized,
@@ -104,7 +105,6 @@ class NPUWorker(Worker):
             torch_profiler_trace_dir = envs.VLLM_TORCH_PROFILER_DIR
             logger.info("Profiling enabled. Traces will be saved to: %s",
                         torch_profiler_trace_dir)
-            import torch_npu
 
             experimental_config = torch_npu.profiler._ExperimentalConfig(
                 export_type=torch_npu.profiler.ExportType.Text,


### PR DESCRIPTION
# What does this PR do?
The purpose of this PR is to add implementation of torch profiling for npu worker.
# Testing
```
INFO 01-21 05:47:56 __init__.py:28] Available plugins for group vllm.platform_plugins:
INFO 01-21 05:47:56 __init__.py:30] name=ascend_plugin, value=vllm_ascend:register
INFO 01-21 05:47:56 __init__.py:32] all available plugins for group vllm.platform_plugins will be loaded.
INFO 01-21 05:47:56 __init__.py:34] set environment variable VLLM_PLUGINS to control which plugins to load.
INFO 01-21 05:47:56 __init__.py:42] plugin ascend_plugin loaded.
INFO 01-21 05:47:56 __init__.py:170] Platform plugin ascend_plugin is activated
INFO 01-21 05:48:07 config.py:520] This model supports multiple tasks: {'embed', 'generate', 'classify', 'score', 'reward'}. Defaulting to 'generate'.
INFO 01-21 05:48:07 llm_engine.py:232] Initializing an LLM engine (v0.1.dev4172+gb3899b3) with config: model='/root/wl/models/opt-125m', speculative_config=None, tokenizer='/root/wl/models/opt-125m', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=2048, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, kv_cache_dtype=auto, quantization_param_path=None, device_config=npu, decoding_config=DecodingConfig(guided_decoding_backend='xgrammar'), observability_config=ObservabilityConfig(otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=0, served_model_name=/root/wl/models/opt-125m, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=False, chunked_prefill_enabled=False, use_async_output_proc=True, disable_mm_preprocessor_cache=False, mm_processor_kwargs=None, pooler_config=None, compilation_config={"splitting_ops":["vllm.unified_attention","vllm.unified_attention_with_output"],"candidate_compile_sizes":[],"compile_sizes":[],"capture_sizes":[256,248,240,232,224,216,208,200,192,184,176,168,160,152,144,136,128,120,112,104,96,88,80,72,64,56,48,40,32,24,16,8,4,2,1],"max_capture_size":256}, use_cached_outputs=False, 
INFO 01-21 05:48:08 importing.py:14] Triton not installed or not compatible; certain GPU-related functions will not be available.
./vllm_profile
[W121 05:48:16.571034461 compiler_depend.ts:659] Warning: 0Failed to find function aclrtSynchronizeDeviceWithTimeout (function operator())
INFO 01-21 05:48:16 model_runner.py:1097] Starting to load model /root/wl/models/opt-125m...
Loading pt checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading pt checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  2.78it/s]
Loading pt checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  2.78it/s]

INFO 01-21 05:48:17 model_runner.py:1102] Loading model weights took 0.2334 GB
INFO 01-21 05:48:19 executor_base.py:95] # CPU blocks: 98554, # CPU blocks: 7281
INFO 01-21 05:48:19 executor_base.py:100] Maximum concurrency for 2048 tokens per request: 769.95x
INFO 01-21 05:48:19 llm_engine.py:429] init engine (profile, create kv cache, warmup model) took 2.12 seconds
Processed prompts: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:05<00:00,  1.28s/it, est. speed input: 5.08 toks/s, output: 12.51 toks/s]
2025-01-21 05:48:28 [WARNING] [131442] profiler.py: Incorrect schedule: Stop profiler while current state is RECORD which may result in incomplete parsed data.
huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
        - Avoid using `tokenizers` before the fork if possible
        - Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
2025-01-21 05:48:29 [INFO] [132657] profiler.py: Start parsing profiling data: /root/wl/vllm_npu/vllm/examples/vllm_profile/4bc495917c31_131442_20250121054823434_ascend_pt
2025-01-21 05:48:31 [WARNING] [132657] profiler.py: 14 memory record(s) are incomplete.
2025-01-21 05:48:35 [INFO] [132698] profiler.py: CANN profiling data parsed in a total time of 0:00:06.165478
2025-01-21 05:48:40 [INFO] [132657] profiler.py: All profiling data parsed in a total time of 0:00:10.864254
Prompt: 'Hello, my name is', Generated text: ' John, I am the daughter of Bill and Jocelyn, I am married'
Prompt: 'The president of the United States is', Generated text: " States President. I don't like him.\nThis is my favorite comment so"
Prompt: 'The capital of France is', Generated text: " Texas and everyone I've spoken to in the city knows the state's name,"
Prompt: 'The future of AI is', Generated text: ' people trying to turn a good computer into a machine, not a computer being human'
```