### PR TITLE
[Misc] Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!--  Thanks for sending a pull request!
+
+BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html
+
+-->
+### What this PR does / why we need it?
+<!--
+- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
+If possible, please consider writing useful notes for better and faster reviews in your PR.
+
+- Please clarify why the changes are needed. For instance, the use case and bug description.
+
+- Fixes #
+-->
+
+### Does this PR introduce _any_ user-facing change?
+<!--
+Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
+Documentation-only updates are not considered user-facing changes.
+-->
+
+### How was this patch tested?
+<!--
+CI passed with new added/existing test.
+If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
+If tests were not added, please describe why they were not added and/or why it was difficult to add.
+-->
+


### PR DESCRIPTION
### What this PR does / why we need it?

This patch adds the PULL_REQUEST_TEMPLATE.md to help contributors write up a clear commit message

The PR template was inspired by:
- https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1
- https://github.com/apache/spark/blob/master/.github/PULL_REQUEST_TEMPLATE

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Preview on this PR message