### PR TITLE
[Misc] Complete vllm-ascend setup info

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 #
 # Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
 # This file is a part of the vllm-ascend project.
+# Adapted from https://github.com/vllm-project/vllm/blob/main/setup.py
+# Copyright 2023 The vLLM team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,6 +27,16 @@ ROOT_DIR = os.path.dirname(__file__)
 
 def get_path(*filepath) -> str:
     return os.path.join(ROOT_DIR, *filepath)
+
+
+def read_readme() -> str:
+    """Read the README file if present."""
+    p = get_path("README.md")
+    if os.path.isfile(p):
+        with open(get_path("README.md"), encoding="utf-8") as f:
+            return f.read()
+    else:
+        return ""
 
 
 def get_requirements() -> List[str]:
@@ -52,15 +64,32 @@ def get_requirements() -> List[str]:
 
 setup(
     name='vllm_ascend',
-    version='0.1',
-    packages=['vllm_ascend'],
-    install_requires=get_requirements(),
-    extras_require={
-        "tensorizer": ["tensorizer>=2.9.0"],
-        "runai": ["runai-model-streamer", "runai-model-streamer-s3", "boto3"],
-        "audio": ["librosa", "soundfile"],  # Required for audio processing
-        "video": ["decord"]  # Required for video processing
+    # Follow:
+    # https://packaging.python.org/en/latest/specifications/version-specifiers
+    version='0.1.0a1',
+    author="vLLM-Ascend team",
+    license="Apache 2.0",
+    description=("vLLM Ascend backend plugin"),
+    long_description=read_readme(),
+    long_description_content_type="text/markdown",
+    url="https://github.com/vllm-project/vllm-ascend",
+    project_urls={
+        "Homepage": "https://github.com/vllm-project/vllm-ascend",
     },
-    entry_points={
-        'vllm.platform_plugins': ["ascend_plugin = vllm_ascend:register"]
-    })
+    classifiers=[
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "License :: OSI Approved :: Apache Software License",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Information Technology",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Topic :: Scientific/Engineering :: Information Analysis",
+    ],
+    packages=['vllm_ascend'],
+    python_requires=">=3.9",
+    install_requires=get_requirements(),
+    extras_require={},
+    entry_points={'vllm.platform_plugins': ["ascend = vllm_ascend:register"]})


### PR DESCRIPTION
### What this PR does / why we need it?

This patch align with the meta data of the vllm community and complete the necessary information:

- Add copyright
- Update version:  0.1.0a1 alpha release follow https://packaging.python.org/en/latest/specifications/version-specifiers
- Add author/license/description
- Remove extras_require

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?
```
# Prepare
$ python3 -m venv ./.venv-test
$ source ./.venv-test/bin/activate

# Install without failaure
$ pip install -e . --no-deps

# Check metadata as exptected
$ ls ./.venv-test/lib/python3.12/site-packages/vllm_ascend-0.1.0a1.dist-info
INSTALLER        LICENSE          METADATA         RECORD           REQUESTED        WHEEL            direct_url.json  entry_points.txt top_level.txt
```